### PR TITLE
feat: Beim Aufruf verschiedenster Vorschlägen (Partner oder Gruppen) …

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -699,6 +699,7 @@ class PartnervorschlagForPersonIDOperations(Resource):
     @secured
     def get(self, person_id):
         adm = Admin()
+        adm.check_anfragen()
         return adm.get_best_partner_vorschlag_for_person_id(person_id)
 
 
@@ -710,6 +711,7 @@ class EingehendePartnervorschlaegeForPersonIDOperations(Resource):
     @secured
     def get(self, person_id):
         adm = Admin()
+        adm.check_anfragen()
         return adm.get_eingehende_partner_vorschlaege_for_person_id(person_id)
 
 
@@ -721,6 +723,7 @@ class AusgehendePartnervorschlaegeForPersonIDOperations(Resource):
     @secured
     def get(self, person_id):
         adm = Admin()
+        adm.check_anfragen()
         return adm.get_ausgehende_partner_vorschlaege_for_person_id(person_id)
 
 
@@ -805,6 +808,7 @@ class GruppenvorschlagByPersonIDOperations(Resource):
     @secured
     def get(self, person_id):
         adm = Admin()
+        adm.check_anfragen()
         return adm.get_best_gruppenvorschlag_for_person_id(person_id)
 
 
@@ -816,6 +820,7 @@ class EingehendeGruppenvorschlaegeForPersonIDOperations(Resource):
     @secured
     def get(self, person_id):
         adm = Admin()
+        adm.check_anfragen()
         return adm.get_eingehende_gruppen_vorschlaege_for_person_id(person_id)
 
 
@@ -827,6 +832,7 @@ class AusgehendeGruppenvorschlaegeForPersonIDOperations(Resource):
     @secured
     def get(self, person_id):
         adm = Admin()
+        adm.check_anfragen()
         return adm.get_ausgehende_gruppen_vorschlaege_for_person_id(person_id)
 
 
@@ -838,6 +844,7 @@ class EingehendeGruppenvorschlaegeForGruppenIDOperations(Resource):
     @secured
     def get(self, gruppen_id):
         adm = Admin()
+        adm.check_anfragen()
         return adm.get_eingehende_gruppen_vorschlaege_for_gruppen_id(gruppen_id)
 
 
@@ -849,6 +856,7 @@ class GruppenvorschlaegeForGruppenIDOperations(Resource):
     @secured
     def get(self, gruppen_id):
         adm = Admin()
+        adm.check_anfragen()
         return adm.get_gruppen_vorschlaege_for_gruppen_id(gruppen_id)
 
 

--- a/src/server/db/GruppenVorschlagMapper.py
+++ b/src/server/db/GruppenVorschlagMapper.py
@@ -1,5 +1,6 @@
 from server.bo.GruppenVorschlag import GruppenVorschlag
 from server.db.Mapper import Mapper
+from datetime import datetime
 
 
 class GruppenVorschlagMapper (Mapper):
@@ -295,6 +296,33 @@ class GruppenVorschlagMapper (Mapper):
 
         return result
 
+    def find_all_anfragen(self):
+        result = []
+        cursor = self._cnx.cursor()
+        command = "SELECT * FROM gruppen_vorschlaege WHERE matchpoints=1 AND " \
+                  "((entscheidung_person=TRUE AND entscheidung_gruppe=FALSE) " \
+                  "OR (entscheidung_gruppe=TRUE AND entscheidung_person=FALSE)) "
+        cursor.execute(command)
+        tuples = cursor.fetchall()
+
+        for (id, erstellungszeitpunkt, person_id, gruppen_id, aehnlichkeit, matchpoints, entscheidung_person,
+             entscheidung_gruppe) in tuples:
+            gruppen_vorschlag = GruppenVorschlag()
+            gruppen_vorschlag.set_id(id)
+            gruppen_vorschlag.set_erstellungszeitpunkt(erstellungszeitpunkt)
+            gruppen_vorschlag.set_person_id(person_id)
+            gruppen_vorschlag.set_gruppen_id(gruppen_id)
+            gruppen_vorschlag.set_aehnlichkeit(aehnlichkeit)
+            gruppen_vorschlag.set_matchpoints(matchpoints)
+            gruppen_vorschlag.set_entscheidung_person(entscheidung_person)
+            gruppen_vorschlag.set_entscheidung_gruppe(entscheidung_gruppe)
+            result.append(gruppen_vorschlag)
+
+        self._cnx.commit()
+        cursor.close()
+
+        return result
+
     def insert(self, gruppen_vorschlag: GruppenVorschlag):
         """
 
@@ -336,9 +364,10 @@ class GruppenVorschlagMapper (Mapper):
         """
         cursor = self._cnx.cursor()
 
-        command = "UPDATE gruppen_vorschlaege SET person_id=%s, gruppen_id=%s, " \
+        command = "UPDATE gruppen_vorschlaege SET erstellungszeitpunkt=%s, person_id=%s, gruppen_id=%s, " \
                   "aehnlichkeit=%s, matchpoints=%s, entscheidung_person=%s, entscheidung_gruppe=%s WHERE id=%s"
         data = (
+            datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             gruppen_vorschlag.get_person_id(),
             gruppen_vorschlag.get_gruppen_id(),
             gruppen_vorschlag.get_aehnlichkeit(),


### PR DESCRIPTION
…wird die neue Funktion check_anfragen() in der Admin.py aufgerufen, welche den Erstellungszeitpunkt (welcher beim Updaten aktualisiert wird) aller offenen Anfragen (einseitig und positiv entschiedene Vorschläge) mit dem aktuellen Zeitpunkt abgleicht und bei einer Differenz von mindestens fünf Tagen wieder zurücksetzt, also die Anfrage wird zurückgezogen.

Beim Updaten von Gruppenvorschlägen und Partnervorschlägen wird in dessen Mapper automatisch der Erstellungszeitpunkt auf den aktuellen Zeitpunkt gesetzt.